### PR TITLE
Fix relocation issues when disabled

### DIFF
--- a/api/src/main/java/revxrsal/zapper/DependencyManager.java
+++ b/api/src/main/java/revxrsal/zapper/DependencyManager.java
@@ -82,8 +82,10 @@ public final class DependencyManager implements DependencyScope {
                 if (!relocations.isEmpty() && !relocated.exists()) {
                     Relocator.relocate(file, relocated, relocations);
                     file.delete(); // no longer need the original dependency
+                    loaderWrapper.addURL(relocated.toURI().toURL());
+                } else {
+                    loaderWrapper.addURL(file.toURI().toURL());
                 }
-                loaderWrapper.addURL(relocated.toURI().toURL());
             }
         } catch (DependencyDownloadException e) {
             if (e.getCause() instanceof UnknownHostException) {

--- a/api/src/main/java/revxrsal/zapper/RuntimeLibPluginConfiguration.java
+++ b/api/src/main/java/revxrsal/zapper/RuntimeLibPluginConfiguration.java
@@ -54,10 +54,13 @@ public final class RuntimeLibPluginConfiguration {
     private static @NotNull List<Relocation> parseRelocations() throws IOException {
         List<Relocation> relocations = new ArrayList<>();
         InputStream stream = ClassLoaderReader.getResource("zapper/relocations.txt");
-        for (String line : readAllLines(stream)) {
-            String[] split = line.split(":");
-            relocations.add(new Relocation(split[0], split[1]));
+        if(stream != null) {
+            for (String line : readAllLines(stream)) {
+                String[] split = line.split(":");
+                relocations.add(new Relocation(split[0], split[1]));
+            }
         }
+
         return relocations;
     }
 


### PR DESCRIPTION
When relocation is not configured, no relocated jars are produced, and no relocations.txt file is generated. As a result no dependencies will correctly be loaded into the URLClassloader context meaning no dependencies will be resolved.