### PR TITLE
Fix transitive dependencies with no scope tag

### DIFF
--- a/api/src/main/java/revxrsal/zapper/transitive/TransitiveResolver.java
+++ b/api/src/main/java/revxrsal/zapper/transitive/TransitiveResolver.java
@@ -162,7 +162,7 @@ public final class TransitiveResolver {
                     }
                     if (groupId.equals("${project.groupId}")) groupId = dependency.getGroupId();
                     if (version.equals("${project.version}")) version = dependency.getVersion();
-                    if (scope != null && scopes.contains(scope) && !version.isEmpty()) {
+                    if (scopes.contains(scope) && !version.isEmpty()) {
                         Dependency e = new Dependency(groupId, artifactId, version);
                         dependencies.add(e);
                     }

--- a/api/src/main/java/revxrsal/zapper/transitive/TransitiveResolver.java
+++ b/api/src/main/java/revxrsal/zapper/transitive/TransitiveResolver.java
@@ -154,7 +154,7 @@ public final class TransitiveResolver {
                     String groupId = dependencyBlock.getElementsByTagName("groupId").item(0).getTextContent();
                     String artifactId = dependencyBlock.getElementsByTagName("artifactId").item(0).getTextContent();
                     String version = "";
-                    MavenScope scope = null;
+                    MavenScope scope = MavenScope.COMPILE;
                     try {
                         version = dependencyBlock.getElementsByTagName("version").item(0).getTextContent();
                         scope = MavenScope.fromString(dependencyBlock.getElementsByTagName("scope").item(0).getTextContent());


### PR DESCRIPTION
When fetching transitive dependencies there may not be a `<scope>` tag in the POM. In this cases, Maven uses the `compile` scope as a default value.
Zapper in this case would skip the dependency, due to a check of the scope variable (which it is initialized as null).

The fix is as simple as changing the initial value from null to `MavenScope.COMPILE` and removing the `scope != null` condition.